### PR TITLE
Roll version to 1.9-SNAPSHOT

### DIFF
--- a/device/pom.xml
+++ b/device/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>sdo</artifactId>
   <groupId>org.sdo</groupId>
-  <version>1.8</version>
+  <version>1.9-SNAPSHOT</version>
   <name>SDO</name>
   <packaging>pom</packaging>
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/to0client/pom.xml
+++ b/to0client/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The version for PRI packages are rolled to 1.9-SNAPSHOT to prepare for
next release.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>