### PR TITLE
Fix: Change path to save OC file

### DIFF
--- a/demo/device/application.properties
+++ b/demo/device/application.properties
@@ -46,7 +46,7 @@ org.sdo.device.key=creds/device.key
 # Directory in which OC file would be saved after DI/TO2 operation. Ensure that
 # the directory is present.
 # If not set, OC file is saved in /tmp folder.
-org.sdo.device.output-dir=creds/saved
+org.sdo.device.output-dir=creds
 
 # org.sdo.device.stop-after-di (optional): Boolean value (true/false)
 # If true, Device execution will stop after DI. If false, TO1 will be initiated.


### PR DESCRIPTION
The default OC file is present at demo/device/creds folder whereas the
newly generated OC files are saved at demo/device/creds/saved folder.
For automation, it might be better to save the newly generated OC files
at the same location (i.e. demo/device/creds).

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>