### PR TITLE
make OnDie cache optional for current configurations

### DIFF
--- a/owner/src/main/java/org/sdo/pri/owner/OwnerApp.java
+++ b/owner/src/main/java/org/sdo/pri/owner/OwnerApp.java
@@ -515,7 +515,7 @@ public class OwnerApp extends SpringBootServletInitializer implements WebMvcConf
     }
   }
 
-  @Value("${org.sdo.ondiecache.cachedir:}")
+  @Value("${org.sdo.ondiecache.cachedir:#{null}}")
   void setOnDieCacheDir(String cacheDir) {
     this.myOnDieCacheDir = cacheDir;
   }

--- a/protocol/src/main/java/org/sdo/pri/OnDieCache.java
+++ b/protocol/src/main/java/org/sdo/pri/OnDieCache.java
@@ -30,7 +30,7 @@ public class OnDieCache {
 
   private boolean autoUpdate = false;
 
-  private String cacheDir = "";
+  private String cacheDir = null;
 
   private List<URL> sourceUrl = new ArrayList<URL>();
 
@@ -60,24 +60,23 @@ public class OnDieCache {
       // defaults: the public facing sites containing OnDie artifacts
       this.sourceUrl.add(new URL("https://tsci.intel.com/content/OnDieCA/crls/"));
     }
-    if (cacheDir == null) {
-      throw new IOException("OnDieCertCache: cache directory not specified.");
-    }
-    File cache = new File(cacheDir);
-    if (!cache.exists()) {
-      throw new IOException("OnDieCertCache: cache directory does not exist: " + cacheDir);
-    }
-    if (!cache.isDirectory()) {
-      throw new IOException("OnDieCertCache: cache directory must be a directory: " + cacheDir);
-    }
+    if (cacheDir != null) {
+      File cache = new File(cacheDir);
+      if (!cache.exists()) {
+        throw new IOException("OnDieCache: cache directory does not exist: " + cacheDir);
+      }
+      if (!cache.isDirectory()) {
+        throw new IOException("OnDieCache: cache directory must be a directory: " + cacheDir);
+      }
 
-    this.cacheDir = cacheDir;
-    this.autoUpdate = autoUpdate;
-    if (autoUpdate) {
-      // update local cache
-      copyFromUrlSources();
+      this.cacheDir = cacheDir;
+      this.autoUpdate = autoUpdate;
+      if (autoUpdate) {
+        // update local cache
+        copyFromUrlSources();
+      }
+      loadCacheMap();
     }
-    loadCacheMap();
   }
 
 


### PR DESCRIPTION
There should be no error if OnDie cache is not configured
until it is actually used by the application. This is to
ensure backwards compatibility.

Signed-off-by: Easterday, John <john.easterday@intel.com>