### PR TITLE
Set the sandbox EPID verifier as default for demo

### DIFF
--- a/demo/owner/application.properties
+++ b/demo/owner/application.properties
@@ -30,7 +30,7 @@ logging.config=logback-spring.xml
 # ignored.
 # If not set, Intel's default EPID verifier will be used.
 # Example: org.sdo.epid.epid-online-url = http://localhost:9999/
-#org.sdo.epid.epid-online-url=
+org.sdo.epid.epid-online-url=https://verify.epid-sbx.trustedservices.intel.com/
 
 # org.sdo.epid.test-mode (optional): Boolean value (true/false)
 # Set this flag to use the EPID development server instead of the

--- a/demo/rendezvous/application.properties
+++ b/demo/rendezvous/application.properties
@@ -26,6 +26,19 @@ logging.config=logback-spring.xml
 # messages.
 server.port=8040
 
+# The URL for the EPID verifier.
+#
+# If left blank, Intel's EPID verifier will be used.
+# If this value is set, the property org.sdo.epid.test-mode
+# will be ignored.
+#
+# Type:        URI
+# Defaults-To: https://verify.epid.trustedservices.intel.com/
+# Affects:     TO1, TO2
+# Example:     org.sdo.epid.epid-online-url = http://localhost:9999/
+
+org.sdo.epid.epid-online-url=https://verify.epid-sbx.trustedservices.intel.com/
+
 # org.sdo.epid.test-mode (optional): Boolean
 # The test-mode parameter indicates whether we should be using EPID development
 # (sandbox) service for verification of the EPID key. Only the sandbox service


### PR DESCRIPTION
For demo operations, the sandbox EPID verifier service is used instead
of production EPID verifier service. Both the services use the same
backend logic.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>