### PR TITLE
Migrate to use Ubuntu 20.04

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y git  \

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,7 @@ Docker Script for Building PRI repository. Using this script you can build the l
 
 ## Prerequisites
 
-- Operating system: **Ubuntu 18.04.**
+- Operating system: **Ubuntu 20.04.**
 
 - Docker engine : **18.06.0**
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -12,7 +12,7 @@ The SDO out-of-the-box demo is organized according to the following directory st
         ├── owner        : Demo Owner
         └── rendezvous   : Demo Rendezvous service
 
-## Packages required for the Ubuntu* 18.04 system
+## Packages required for the Ubuntu* 20.04 system
 
     $ sudo apt install openjdk-11-jdk-headless
 


### PR DESCRIPTION
Migrate build and runtime containers to use Ubuntu 20.04.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>