### PR TITLE
Fix for accessing sandbox RV without proxy

### DIFF
--- a/device/pom.xml
+++ b/device/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>1.9.1</version>
     </dependency>
 
     <dependency>

--- a/device/pom.xml
+++ b/device/pom.xml
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.4.0</spring-boot.version>
+    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/device/src/main/java/org/sdo/pri/device/DeviceApp.java
+++ b/device/src/main/java/org/sdo/pri/device/DeviceApp.java
@@ -306,7 +306,8 @@ public class DeviceApp {
   // The HttpClient which SDO components will use for outgoing HTTP.
   @Bean
   HttpClient httpClient() throws Exception {
-    return HttpClient.newBuilder().sslContext(sslContext()).build();
+    return HttpClient.newBuilder().sslContext(sslContext())
+      .version(HttpClient.Version.HTTP_1_1).build();
   }
 
   // Loggers are handy for telling folks about stuff and junk.

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -57,6 +57,24 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>${tomcat.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>${tomcat.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-annotations-api</artifactId>
+      <version>9.0.40</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>1.9.1</version>
     </dependency>
 
     <dependency>

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-annotations-api</artifactId>
-      <version>9.0.40</version>
+      <version>${tomcat.version}</version>
     </dependency>
   </dependencies>
 

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.4.0</spring-boot.version>
+    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/owner/src/main/java/org/sdo/pri/owner/OwnerApp.java
+++ b/owner/src/main/java/org/sdo/pri/owner/OwnerApp.java
@@ -244,7 +244,8 @@ public class OwnerApp extends SpringBootServletInitializer implements WebMvcConf
   // If we don't have to verify EPID signatures, we don't need this.
   @Bean
   HttpClient httpClient() throws KeyManagementException, NoSuchAlgorithmException {
-    return HttpClient.newBuilder().sslContext(sslContext()).build();
+    return HttpClient.newBuilder().sslContext(sslContext())
+      .version(HttpClient.Version.HTTP_1_1).build();
   }
 
   // (Re)initialize the owner service with those transient bits of state

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>sdo</artifactId>
   <groupId>org.sdo</groupId>
-  <version>1.9</version>
+  <version>1.9.1</version>
   <name>SDO</name>
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <maven-surefire-report-plugin.version>3.0.0-M4</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
     <project-demo-directory>../demo</project-demo-directory>
+    <tomcat.version>9.0.40</tomcat.version>
   </properties>
 
   <modules>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/protocol/src/main/java/org/sdo/pri/OwnerService.java
+++ b/protocol/src/main/java/org/sdo/pri/OwnerService.java
@@ -57,7 +57,8 @@ public class OwnerService implements ProtocolService, Serializable {
   private URL myEpidServiceUrl = EpidConstants.onlineEpidUrlDefault;
   private UUID myG3 = null;
   private transient Function<OwnershipVoucher, UUID> myG3Function = this::defaultG3;
-  private transient HttpClient myHttpClient = HttpClient.newBuilder().build();
+  private transient HttpClient myHttpClient = HttpClient.newBuilder()
+      .version(HttpClient.Version.HTTP_1_1).build();
   private boolean myIsDone = false;
   private KeyExchange myKeyExchange = null;
   private Nonce myN6 = null;

--- a/protocol/src/main/java/org/sdo/pri/RendezvousDeviceService.java
+++ b/protocol/src/main/java/org/sdo/pri/RendezvousDeviceService.java
@@ -24,7 +24,8 @@ import java.util.UUID;
 public class RendezvousDeviceService implements ProtocolService, Serializable {
 
   private URL myEpidServiceUrl = EpidConstants.onlineEpidUrlDefault;
-  private transient HttpClient myHttpClient = HttpClient.newBuilder().build();
+  private transient HttpClient myHttpClient = HttpClient.newBuilder()
+      .version(HttpClient.Version.HTTP_1_1).build();
   private boolean myIsDone = false;
   private Nonce myN4 = null;
   private RedirectionEntry myRedirectionEntry = null;

--- a/protocol/src/test/java/org/sdo/pri/EpidOnlineMaterialTest.java
+++ b/protocol/src/test/java/org/sdo/pri/EpidOnlineMaterialTest.java
@@ -32,7 +32,7 @@ class EpidOnlineMaterialTest {
   @Test
   @Disabled
   void test() throws Exception {
-    HttpClient c = HttpClient.newBuilder().build();
+    HttpClient c = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     EpidOnlineMaterial e = new EpidOnlineMaterial(EpidConstants.sandboxEpidUrlDefault.toURI(), c);
     byte[] b = e.readEpidRestService(gid, EpidLib.EpidVersion.EPID_2_0, EpidLib.MaterialId.SIGRL);
     Assertions.assertArrayEquals(new byte[]{}, b);

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -57,6 +57,24 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>${tomcat.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>${tomcat.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-annotations-api</artifactId>
+      <version>9.0.40</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>1.9.1</version>
     </dependency>
 
     <dependency>

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-annotations-api</artifactId>
-      <version>9.0.40</version>
+      <version>${tomcat.version}</version>
     </dependency>
   </dependencies>
 

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.4.0</spring-boot.version>
+    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/rendezvous/src/main/java/org/sdo/pri/rendezvous/RendezvousApp.java
+++ b/rendezvous/src/main/java/org/sdo/pri/rendezvous/RendezvousApp.java
@@ -200,7 +200,8 @@ public class RendezvousApp extends SpringBootServletInitializer implements WebMv
   // If we don't have to verify EPID signatures, we don't need this.
   @Bean
   HttpClient httpClient() throws KeyManagementException, NoSuchAlgorithmException {
-    return HttpClient.newBuilder().sslContext(sslContext()).build();
+    return HttpClient.newBuilder().sslContext(sslContext())
+      .version(HttpClient.Version.HTTP_1_1).build();
   }
 
   private ProtocolService initRendezvousService(RendezvousDeviceService service)

--- a/to0client/pom.xml
+++ b/to0client/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>sdo</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+    <spring-boot.version>2.4.0</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>protocol</artifactId>
-      <version>1.9</version>
+      <version>1.9.1</version>
     </dependency>
 
     <dependency>

--- a/to0client/pom.xml
+++ b/to0client/pom.xml
@@ -26,7 +26,7 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.4.0</spring-boot.version>
+    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/to0client/src/main/java/org/sdo/pri/to0client/To0ClientApp.java
+++ b/to0client/src/main/java/org/sdo/pri/to0client/To0ClientApp.java
@@ -230,7 +230,8 @@ public class To0ClientApp {
   // The HttpClient which SDO components will use for outgoing HTTP.
   @Bean
   HttpClient httpClient() throws Exception {
-    return HttpClient.newBuilder().sslContext(sslContext()).build();
+    return HttpClient.newBuilder().sslContext(sslContext())
+      .version(HttpClient.Version.HTTP_1_1).build();
   }
 
   // Loggers are handy for telling folks about stuff and junk.


### PR DESCRIPTION
When PRI components (to0client and device) are used in open network,
they are not able to connect to hosted Rendezvous Service.

The issue is resolved by setting the HTTP version to 1.1 explicitly
while creating the required HTTP clients.

While at it, update the third-party package vesions to fix known
security vulnerabilities.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>