### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/device/pom.xml
+++ b/device/pom.xml
@@ -26,7 +26,8 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <dependencyManagement>
@@ -51,7 +52,26 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -26,7 +26,8 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <dependencyManagement>
@@ -51,6 +52,30 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven-surefire-report-plugin.version>3.0.0-M5</maven-surefire-report-plugin.version>
     <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
     <project-demo-directory>../demo</project-demo-directory>
-    <tomcat.version>9.0.53</tomcat.version>
+    <tomcat.version>9.0.56</tomcat.version>
   </properties>
 
   <modules>

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -26,7 +26,8 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <dependencyManagement>
@@ -51,6 +52,30 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>

--- a/to0client/pom.xml
+++ b/to0client/pom.xml
@@ -26,7 +26,8 @@
   mvn versions:update-properties
   -->
   <properties>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <dependencyManagement>
@@ -51,7 +52,26 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
  Upgrading dependencies to the latest version

  org.springframework.boot:spring.* from 2.5.5 ==> 2.5.7
  tomcat => 9.0.56
  log4j => 2.16.0

Signed-off-by: Davis Benny <davis.benny@intel.com>