### PR TITLE
Upgrading log4j version from 2.16.0 to 2.17.1

### DIFF
--- a/device/pom.xml
+++ b/device/pom.xml
@@ -27,7 +27,7 @@
   -->
   <properties>
     <spring-boot.version>2.5.7</spring-boot.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencyManagement>

--- a/owner/pom.xml
+++ b/owner/pom.xml
@@ -27,7 +27,7 @@
   -->
   <properties>
     <spring-boot.version>2.5.7</spring-boot.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencyManagement>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -26,8 +26,8 @@
   mvn versions:update-properties
   -->
   <properties>
-    <bcprov-jdk15on.version>1.68</bcprov-jdk15on.version>
-    <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
+    <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
+    <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
   </properties>
 
   <dependencies>

--- a/rendezvous/pom.xml
+++ b/rendezvous/pom.xml
@@ -27,7 +27,7 @@
   -->
   <properties>
     <spring-boot.version>2.5.7</spring-boot.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencyManagement>

--- a/to0client/pom.xml
+++ b/to0client/pom.xml
@@ -27,7 +27,7 @@
   -->
   <properties>
     <spring-boot.version>2.5.7</spring-boot.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
  Upgrading log4j version from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>